### PR TITLE
feat: QR code to connect to issuer in case of no compatible credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ At the moment, all configuration is done by environment variables. While most of
 | NEXT_PUBLIC_PORT             | Port where app is listening                   | 3000                                                                                                                 |
 | CREDENTIAL_DEFINITION_ID     | Unique identifier or Credential types         | `none`                                                                                                               |
 | SERVICE_AGENT_ADMIN_BASE_URL | Service agent base URL                        | `none`                                                                                                               |
+| ISSUER_DID | Optional public DID to let users connect to get their credentials in case they don't have any compatible credential                       | `none`                                                                                                               |
+| ISSUER_LABEL | A label to show in the invitation to credential issuer                       | Issuer                                                  |
+| ISSUER_IMAGE_URL | An URL pointing to an image to show in the invitation to credential issuer                       | `none`                                                                                                               |
+|
 
 **Note:** By default, it is recommended to use the following values for `CREDENTIAL_DEFINITION_ID` and `SERVICE_AGENT_ADMIN_BASE_URL`:
 

--- a/app/[locale]/presentation.tsx
+++ b/app/[locale]/presentation.tsx
@@ -64,6 +64,7 @@ export default function Presentation({ presentationEventMessage }: Props) {
                     level={"H"}
                   />
                 </div>
+                <button onClick={() => window.location.reload()}>Restart</button>
               </>
             )}
           </>

--- a/app/[locale]/presentation.tsx
+++ b/app/[locale]/presentation.tsx
@@ -1,6 +1,7 @@
 import { useTranslations } from "next-intl";
 import { PresentationEventMessage } from "@/app/lib/definitions";
 import PresentationClaims from "./presentation-claims";
+import { QRCodeSVG } from "qrcode.react";
 import { ReactElement, useMemo } from "react";
 
 type Props = {
@@ -9,7 +10,7 @@ type Props = {
 
 export default function Presentation({ presentationEventMessage }: Props) {
   const t = useTranslations();
-  const { claims, status } = presentationEventMessage;
+  const { claims, status, issuerInvitationUrl } = presentationEventMessage;
   console.log("presentation status:", status);
 
   const render: Record<PresentationEventMessage["status"], ReactElement> =
@@ -43,9 +44,27 @@ export default function Presentation({ presentationEventMessage }: Props) {
           </div>
         ),
         "no-compatible-credentials": (
-          <p className="font-bold text-xl text-orange-500">
-            <span>{t("noCompatibleCredentials")}</span>
-          </p>
+          <>
+            <p className="font-bold text-xl text-orange-500">
+              <span>{t("noCompatibleCredentials")}</span>
+            </p>
+            { issuerInvitationUrl && (
+            <><div>
+                <p className="md:mb-2 lg:mb-3 ">
+                  <span className="text-hologram-color text-xl md:text-xl lg:text-2xl font-semibold text-center">
+                    {t("scanToConnectToIssuer")}
+                  </span>
+                </p>
+              </div><div className="w-[300px] h-[300px] flex justify-center items-center mb-6 bg-white border-solid border-2 rounded-2xl border-gray-300">
+                  <QRCodeSVG
+                    value={issuerInvitationUrl}
+                    size={256}
+                    bgColor={"#ffffff"}
+                    fgColor={"#000000"}
+                    level={"H"} />
+                </div></>)}
+          </>
+        
         ),
         "verification-error": (
           <p className="font-bold text-xl text-red-500">

--- a/app/[locale]/presentation.tsx
+++ b/app/[locale]/presentation.tsx
@@ -45,26 +45,28 @@ export default function Presentation({ presentationEventMessage }: Props) {
         ),
         "no-compatible-credentials": (
           <>
-            <p className="font-bold text-xl text-orange-500">
+            <p className="font-bold text-xl text-black">
               <span>{t("noCompatibleCredentials")}</span>
             </p>
-            { issuerInvitationUrl && (
-            <><div>
+            {issuerInvitationUrl && (
+              <>
                 <p className="md:mb-2 lg:mb-3 ">
                   <span className="text-hologram-color text-xl md:text-xl lg:text-2xl font-semibold text-center">
                     {t("scanToConnectToIssuer")}
                   </span>
                 </p>
-              </div><div className="w-[300px] h-[300px] flex justify-center items-center mb-6 bg-white border-solid border-2 rounded-2xl border-gray-300">
+                <div className="w-[300px] h-[300px] flex justify-center items-center mb-6 bg-white border-solid border-2 rounded-2xl border-gray-300">
                   <QRCodeSVG
                     value={issuerInvitationUrl}
                     size={256}
                     bgColor={"#ffffff"}
                     fgColor={"#000000"}
-                    level={"H"} />
-                </div></>)}
+                    level={"H"}
+                  />
+                </div>
+              </>
+            )}
           </>
-        
         ),
         "verification-error": (
           <p className="font-bold text-xl text-red-500">
@@ -77,7 +79,7 @@ export default function Presentation({ presentationEventMessage }: Props) {
           </p>
         ),
       };
-    }, [claims, t]);
+    }, [claims, t, issuerInvitationUrl]);
 
   return render[status];
 }

--- a/app/hook/useSocket.ts
+++ b/app/hook/useSocket.ts
@@ -51,8 +51,13 @@ export const useSocket = () => {
           const transformedClaims = transformClaimsData(msg.claims);
           setPresentationEventMessage({ ...msg, claims: transformedClaims });
         } else {
-          const { ref, status, proofExchangeId } = msg;
-          setPresentationEventMessage({ ref, status, proofExchangeId });
+          const { ref, status, proofExchangeId, issuerInvitationUrl } = msg;
+          setPresentationEventMessage({
+            ref,
+            status,
+            proofExchangeId,
+            issuerInvitationUrl,
+          });
         }
       }
     );

--- a/app/lib/definitions.ts
+++ b/app/lib/definitions.ts
@@ -38,6 +38,7 @@ export type OriginalPresentationEventMessage = {
     | "verification-error"
     | "unspecified-error";
   proofExchangeId: string;
+  issuerInvitationUrl?: string;
 };
 
 export type PresentationEventMessage = Omit<

--- a/docker-dev/docker-compose.yaml
+++ b/docker-dev/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
       - NEXT_PUBLIC_BASE_URL=http://192.168.149.127:2904
       - SERVICE_AGENT_ADMIN_BASE_URL=http://192.168.149.127:3000
       - CREDENTIAL_DEFINITION_ID=did:web:unic-id-issuer.demos.dev.2060.io?service=anoncreds&relativeRef=/credDef/9rJib8YFi1JdxhdUmjMKEiYj49CNdMa9cEn42z4nouYS
+      - ISSUER_DID=did:web:unic-id-issuer.demos.dev.2060.io
+      - ISSUER_LABEL=Chatbot Demo
     networks:
       - verifier
 

--- a/docker-dev/docker-compose.yaml
+++ b/docker-dev/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - NEXT_PUBLIC_PORT=3000
       - NEXT_PUBLIC_BASE_URL=http://192.168.149.127:2904
       - SERVICE_AGENT_ADMIN_BASE_URL=http://192.168.149.127:3000
-      - CREDENTIAL_DEFINITION_ID=did:web:unic-id-issuer.demos.dev.2060.io?service=anoncreds&relativeRef=/credDef/9rJib8YFi1JdxhdUmjMKEiYj49CNdMa9cEn42z4nouYS
+      - CREDENTIAL_DEFINITION_ID=did:web:unic-id-issuer.demos.dev.2060.io?service=anoncreds&relativeRef=/credDef/3Wa9tm1YbVZ9YEpT5Cdxm6KAtDFsoTJJyDNBbYGzBhhp
       - ISSUER_DID=did:web:unic-id-issuer.demos.dev.2060.io
       - ISSUER_LABEL=Chatbot Demo
     networks:

--- a/messages/en.json
+++ b/messages/en.json
@@ -6,6 +6,7 @@
   "requestRefused": "Request Refused!",
   "requestConnected": "Connection established. Please wait",
   "noCompatibleCredentials": "User does not have compatible credentials in his wallet",
+  "scanToConnectToIssuer": "Scan this QR from your Hologram app to connect to the issuer",
   "verificationError": "Credential Verification Error",
   "unspecifiedError": "Ups! Something went wrong"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -6,6 +6,7 @@
   "requestRefused": "Solicitud rechazada!",
   "requestConnected": "Conexión establecida. Por favor espera",
   "noCompatibleCredentials": "El usuario no tiene credenciales compatibles en su billetera",
+  "scanToConnectToIssuer": "Escanea este QR desde tu app de Hologram para conectar con el emisor",
   "verificationError": "Error de verificación de la credencial",
   "unspecifiedError": "Ups! Algo salió mal"
 }


### PR DESCRIPTION
Show the QR code to connect to issuer (if defined in configuration) when a presentation with no compatible credentials status is received.

I could not test it properly yet because for some reason I cannot make my local Service Agent to take into account the callback URL, so it is not posting any updates to the presentation.

If you are able to test it @DanielFRico @lotharking please let me know.