### PR TITLE
feat: generate hologram.zone short URL

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -31,7 +31,7 @@ export default function Home() {
       </div>
       <div className="w-[300px] h-[300px] flex justify-center items-center mb-6 bg-white border-solid border-2 rounded-2xl border-gray-300">
         <QRCodeSVG
-          value={requestQRState?.shortUrl ?? ""}
+          value={requestQRState.invitationUrl ?? ""}
           size={256}
           bgColor={"#ffffff"}
           fgColor={"#000000"}

--- a/app/hook/useSocket.ts
+++ b/app/hook/useSocket.ts
@@ -30,10 +30,10 @@ export const useSocket = () => {
 
     socketIo.on("generateQREventMessage", (msg) => {
       console.log("generateQREventMessage", msg);
-      if (msg.ok && msg.shortUrl) {
+      if (msg.ok && msg.invitationUrl) {
         setRequestQRState({
           loading: false,
-          shortUrl: msg.shortUrl,
+          invitationUrl: msg.invitationUrl,
         });
       } else {
         setRequestQRState({

--- a/app/lib/definitions.ts
+++ b/app/lib/definitions.ts
@@ -5,7 +5,7 @@ export type QRRequestResponse = {
 };
 
 export type UIResponse = {
-  shortUrl?: string;
+  invitationUrl?: string;
   ok: boolean;
   error?: string;
 };
@@ -13,7 +13,7 @@ export type UIResponse = {
 export type QRRequestState = {
   loading: boolean;
   error?: string;
-  shortUrl?: string;
+  invitationUrl?: string;
 };
 
 export type OriginalClaim = {

--- a/server.js
+++ b/server.js
@@ -71,9 +71,10 @@ app.prepare().then(() => {
           body: JSON.stringify(requestBody),
         });
         const result = await response.json();
+        if (!result.shortUrl) throw Error('Result from Service Agent does not contain any short URL')
         message = {
           ok: true,
-          shortUrl: result?.shortUrl,
+          invitationUrl: `https://hologram.zone/?_url=${Buffer.from(result.shortUrl).toString('base64url')}`,
         };
       } catch (error) {
         console.error(error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2762,16 +2762,8 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2857,14 +2849,8 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
The goal is for the proof request QR Code to have an URL whose domain is hologram.zone. This way, when scanned from the regular Camera app it will open either Hologram app or website (where the user will be prompted to open or install the app).

This closes https://github.com/2060-io/unic.id-generic-verifier-dts/issues/20, but will be fully working once `_url` parameter is supported in [hologram.zone](https://github.com/2060-io/hologram.zone-website).