### PR TITLE
feat: support JSON_SCHEMA_CREDENTIAL_ID for proof requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,19 @@ All settings are configured by environment variables.
 
 | Variable                     | Description                                                                                                         | Default value         |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| NEXT_PUBLIC_BASE_URL         | Public URL (without port) where the app is deployed                                                                       | http://localhost:3000 |
+| NEXT_PUBLIC_BASE_URL         | Public URL (without port) where the app is deployed                                                                 | http://localhost:3000 |
 | NEXT_PUBLIC_PORT             | Port where app is listening                                                                                         | 3000                  |
-| CREDENTIAL_DEFINITION_ID     | AnonCreds credential definition ID of the credential to request       | `none`                |
-| VS_AGENT_ADMIN_BASE_URL | VS Agent Admin API URL (accessible by the app)                                                                                              | `none`                |
-| ISSUER_DID                   | Optional public DID to let users connect to get their credentials in case they don't have any compatible credential | `none`                |
-| ISSUER_LABEL                 | Optional label to show in the invitation to credential issuer                                                              | Issuer                |
-| ISSUER_IMAGE_URL             | Optional URL pointing to an image to show in the invitation to credential issuer                                          | `none`                |
-| ISSUER_VS_AGENT_ADMIN_BASE_URL          | Optional Issuer VS Agent Admin URL: in case no Credential Definition is specified, the Verifier will attempt to get the first credential type from this URL and will use its Credential Definition ID for its requests. Make sure that Generic Verifier has access to it. | `none`                |
+| VS_AGENT_ADMIN_BASE_URL      | VS Agent Admin API URL (accessible by the app)                                                                      | `none`                |
+| JSON_SCHEMA_CREDENTIAL_ID    | JSON Schema Credential ID of the credential to request (e.g. `https://dm.gov-id-tr.demos.dev.2060.io/vt/schemas-gov-id-jsc.json`) | `none`  |
+| ISSUER_DID                   | Issuer DID (`did:webvh`): if `JSON_SCHEMA_CREDENTIAL_ID` is not set, the verifier auto-discovers the credential definition from the issuer's DID-linked resources. Also used to redirect users without a compatible credential. | `none` |
+| ISSUER_LABEL                 | Optional label to show in the invitation to credential issuer                                                       | Issuer                |
+| ISSUER_IMAGE_URL             | Optional URL pointing to an image to show in the invitation to credential issuer                                    | `none`                |
+
+> **Note:** `CREDENTIAL_DEFINITION_ID` and `ISSUER_VS_AGENT_ADMIN_BASE_URL` were supported until v1.3.1 as part of 2060 demo deployments and are no longer supported.
 
 ### Overview
 
-The minimal setup for Generic Verifier app requires to define a `VS_AGENT_ADMIN_BASE_URL` where its VS Agent is located, and either `CREDENTIAL_DEFINITION_ID` or `ISSUER_VS_AGENT_ADMIN_BASE_URL`. If you know beforehand the ID of the credential type you want the verifier to ask for presentation, you can just define the first. Otherwise, specify the Issuer VS Agent Admin URL location, so the verifier will dynamically use the first available credential type. This is useful to speed-up demo deployment in cases where credential definition IDs are not deterministic, such as did:web AnonCreds.
+The minimal setup for Generic Verifier requires `VS_AGENT_ADMIN_BASE_URL` and either `JSON_SCHEMA_CREDENTIAL_ID` or `ISSUER_DID` (pointing to a `did:webvh` identifier). If `JSON_SCHEMA_CREDENTIAL_ID` is set, it is sent directly in the proof request. Otherwise, the verifier auto-discovers the credential definition by querying the issuer's DID-linked resources of type `anonCredsCredDef`.
 
 There are also some other optional variables about the Issuer: `ISSUER_DID`, `ISSUER_LABEL` and `ISSUER_IMAGE_URL`. They are defined to allow the creation of an implicit DIDComm out of band invitation to the issuer service, to redirect the user when they don't have the requested credential in their wallet. If you don't specify them it is fine: Generic Verifier will simply show a "no compatible credentials" error in the web frontend.
 
@@ -79,7 +80,7 @@ Once running, you can test your Verifiable Service by following
    First, make sure you have [Hologram Messaging](https://hologram.zone) installed on your mobile device. You can download it from the Google Play Store, Apple App Store, or Huawei App Gallery.
 
 2. **Obtain a Credential from the issuer Verifiable Service**  
-   Your Hologram app's wallet needs to hold a Verifiable Credential that corresponds to `CREDENTIAL_DEFINITION_ID`. If not, make a connection to the issuer service and obtain one.
+   Your Hologram app's wallet needs to hold a Verifiable Credential that matches the configured `JSON_SCHEMA_CREDENTIAL_ID` (or the credential definition auto-discovered from `ISSUER_DID`). If not, make a connection to the issuer service and obtain one.
 
 3. **Scan the QR Code and Present Your Credential**  
    Open your web browser into this web app's URL and, in your mobile device, scan the QR code with Hologram: it will prompt you to present the required credential. After presenting it, you should see a confirmation screen similar to the one shown below.

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -6,6 +6,6 @@ version: 0.0.1
 appVersion: "1.0"
 dependencies:
   - name: vs-agent-chart
-    version: v1.8.0
+    version: v1.10.1
     repository: oci://registry-1.docker.io/veranalabs
     condition: vs-agent-chart.enabled

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -6,6 +6,6 @@ version: 0.0.1
 appVersion: "1.0"
 dependencies:
   - name: vs-agent-chart
-    version: v1.10.1
+    version: v1.10.0
     repository: oci://registry-1.docker.io/veranalabs
     condition: vs-agent-chart.enabled

--- a/charts/README.md
+++ b/charts/README.md
@@ -27,18 +27,19 @@ The `vs-agent` chart can be found here: [vs-agent GitHub Repository](https://git
    - `name`: Set the name of the deployment.
    - `namespace`: Specify the Kubernetes namespace where the chart will be deployed.
    - `domain`: Set the domain for the application.
-   - `extraEnv`: Uncomment and configure the `CREDENTIAL_DEFINITION_ID` variable if needed.
+   - `service.jsonSchemaCredentialId`: Set the JSON Schema Credential ID to request, or leave empty to use `ISSUER_DID` auto-discovery.
    - `vs-agent-chart.enabled`: Set to `true` if you want to enable the `vs-agent` dependency.
 3. If using the `vs-agent` dependency, ensure the `vs-agent` chart is properly configured and deployed.
+
+> **Note:** `CREDENTIAL_DEFINITION_ID` and `ISSUER_VS_AGENT_ADMIN_BASE_URL` were supported until v1.3.1 as part of 2060 demo deployments and are no longer supported. Use `JSON_SCHEMA_CREDENTIAL_ID` or `ISSUER_DID` (did:webvh) instead.
 
 ### Example `values.yaml`
 ```yaml
 name: hologram-generic-verifier-vs
 namespace: default
 domain: example.io
-extraEnv:
-  - name: CREDENTIAL_DEFINITION_ID
-    value: "my-credential-definition-id"
+service:
+  jsonSchemaCredentialId: "https://dm.gov-id-tr.demos.dev.2060.io/vt/schemas-gov-id-jsc.json"
 vs-agent-chart:
   enabled: true
   replicas: 1

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -73,10 +73,8 @@ spec:
               value: "{{ .Values.service.issuerLabel }}"
             - name: ISSUER_IMAGE_URL
               value: "{{ tpl .Values.service.issuerImageUrl . }}"
-            - name: CREDENTIAL_DEFINITION_ID
-              value: "{{ .Values.service.credentialDefinitionId }}"
-            - name: ISSUER_VS_AGENT_ADMIN_BASE_URL
-              value: "{{ .Values.service.issuerVsAgentAdminBaseUrl }}"
+            - name: JSON_SCHEMA_CREDENTIAL_ID
+              value: "{{ .Values.service.jsonSchemaCredentialId }}"
             ports:
             -  containerPort: {{ .Values.containerPort }}
             livenessProbe:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -21,10 +21,9 @@ service:
   issuerDid: did:web:issuer.{{ .Values.global.domain }}
   issuerLabel: test-issuer
   issuerImageUrl: https://i.unic-id-issuer.{{ .Values.global.domain }}/avatar.png
-  # Use only if you want to use the vs-agent with a credential definition Id
-  # If you use both credentialDefinitionId and issuerVsAgentAdminBaseUrl, the issuerVsAgentAdminBaseUrl will be ignored
-  credentialDefinitionId: credential-definition-id
-  # issuerVsAgentAdminBaseUrl: http://issuer:3000
+  # JSON Schema Credential ID for proof requests (e.g. https://dm.gov-id-tr.demos.dev.2060.io/vt/schemas-gov-id-jsc.json)
+  # If not set, ISSUER_DID (did:webvh) will be used to auto-discover the credential definition.
+  jsonSchemaCredentialId: ""
 
 # If you want to use the vs-agent-chart, you can enable it by setting the following:
 # vs-agent-chart.enabled: true

--- a/docker-dev/README.md
+++ b/docker-dev/README.md
@@ -30,7 +30,7 @@ services:
       - NEXT_PUBLIC_PORT=3000
       - NEXT_PUBLIC_BASE_URL=http://192.168.149.127:2904
       - VS_AGENT_ADMIN_BASE_URL=http://vs-agent:3000
-      - CREDENTIAL_DEFINITION_ID=did:web:unic-id-issuer.demos.dev.2060.io?service=anoncreds&relativeRef=/credDef/9rJib8YFi1JdxhdUmjMKEiYj49CNdMa9cEn42z4nouYS
+      - JSON_SCHEMA_CREDENTIAL_ID=https://dm.gov-id-tr.demos.dev.2060.io/vt/schemas-gov-id-jsc.json
     networks:
       - verifier
 

--- a/docker-dev/docker-compose.yaml
+++ b/docker-dev/docker-compose.yaml
@@ -12,14 +12,14 @@ services:
       - NEXT_PUBLIC_PORT=3000
       - NEXT_PUBLIC_BASE_URL=http://192.168.149.127:2904
       - VS_AGENT_ADMIN_BASE_URL=http://vs-agent:3000
-      - CREDENTIAL_DEFINITION_ID=did:web:unic-id-issuer.demos.dev.2060.io?service=anoncreds&relativeRef=/credDef/3Wa9tm1YbVZ9YEpT5Cdxm6KAtDFsoTJJyDNBbYGzBhhp
+      - JSON_SCHEMA_CREDENTIAL_ID=https://dm.gov-id-tr.demos.dev.2060.io/vt/schemas-gov-id-jsc.json
       - ISSUER_DID=did:webvh:QmU1tBocQ6oZN3zaPFrx9hjB5BnzQr1Kb1GvKqY144Qjjp:dm.gov-id-issuer.demos.dev.2060.io
       - ISSUER_LABEL=Gov ID Issuer
     networks:
       - verifier
 
   vs-agent:
-    image: io2060/vs-agent:v1.5.6
+    image: veranalabs/vs-agent:dev
     restart: always
     ports:
       - 3000:3000
@@ -29,7 +29,7 @@ services:
       # - AGENT_PUBLIC_DID=did:web:p2801.ovpndev.2060.io # Enable this line for with public URL
       - AGENT_ENDPOINT=ws://192.168.149.127:3001 # For deployments, use wss and the assigned public URL
       - AGENT_INVITATION_IMAGE_URL=https://s3.minio.dev.2060.io/public/gov-id-issuer.png
-      - AGENT_LABEL=Gov Id Issuer
+      - AGENT_LABEL=Gov Id Verifier (dev)
       - USE_CORS=true
       - EVENTS_BASE_URL=http://verifier-app:2904
     volumes:

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,43 +34,39 @@ app.prepare().then(async () => {
     process.exit(1)
   }
 
-  // Now attempt to get the credential definition id, either from the environment variable or the specified
-  // issuer (provided it does have a VS Agent accessible by us)
-  let credentialDefinitionId = process.env.CREDENTIAL_DEFINITION_ID
+  let credentialDefinitionId: string | undefined
+  let jsonSchemaCredentialId: string | undefined
 
-  if (!credentialDefinitionId) {
-    const issuerVsAgentAdminBaseUrl = process.env.ISSUER_VS_AGENT_ADMIN_BASE_URL
-
-    if (!issuerVsAgentAdminBaseUrl) {
-      console.error(
-        'You must define a CREDENTIAL_DEFINITION_ID, or ISSUER_VS_AGENT_ADMIN_BASE_URL to get the credential definition to request',
-      )
-      process.exit(1)
-    }
-
-    const url = `${issuerVsAgentAdminBaseUrl}/v1/credential-types`
+  if (process.env.JSON_SCHEMA_CREDENTIAL_ID) {
+    jsonSchemaCredentialId = process.env.JSON_SCHEMA_CREDENTIAL_ID
+    console.log(`JSON Schema Credential ID: ${jsonSchemaCredentialId}`)
+  } else if (process.env.ISSUER_DID?.startsWith('did:webvh:')) {
+    const parts = process.env.ISSUER_DID.split(':')
+    const domain = parts.slice(3).join('/')
+    const resourcesUrl = `https://${domain}/resources/?resourceType=anonCredsCredDef`
     try {
-      const response = await fetch(url, {
-        headers: {
-          accept: 'application/json',
-        },
+      const response = await fetch(resourcesUrl, {
+        headers: { accept: 'application/json' },
         method: 'GET',
       })
       const result = await response.json()
-
       const firstCredDefId = result[0]?.id
       if (!firstCredDefId) {
-        console.error('VS Agent response does not contain any valid credential type')
+        console.error('Issuer DID resources do not contain any anonCredsCredDef resource')
         process.exit(1)
       }
       credentialDefinitionId = firstCredDefId
+      console.log(`Credential Definition ID (from issuer DID): ${credentialDefinitionId}`)
     } catch (error) {
-      console.error('Error fetching credential types:', error)
+      console.error('Error fetching anonCredsCredDef resources from issuer DID:', error)
       process.exit(1)
     }
+  } else {
+    console.error(
+      'You must define JSON_SCHEMA_CREDENTIAL_ID or ISSUER_DID (did:webvh) to determine the credential to request',
+    )
+    process.exit(1)
   }
-
-  console.log(`Credential Definition ID: ${credentialDefinitionId}`)
 
   const PORT = process.env.NEXT_PUBLIC_PORT ? Number(process.env.NEXT_PUBLIC_PORT) : 3000
 
@@ -101,9 +97,7 @@ app.prepare().then(async () => {
           callbackUrl: `${PUBLIC_BASE_URL}/api/presentation`,
           ref: data.socketConnectionId,
           requestedCredentials: [
-            {
-              credentialDefinitionId,
-            },
+            jsonSchemaCredentialId ? { jsonSchemaCredentialId } : { credentialDefinitionId },
           ],
         }
         const response = await fetch(url, {


### PR DESCRIPTION
**Changes:**
- Added `JSON_SCHEMA_CREDENTIAL_ID` as the new way to specify the credential to request in proof presentations.
- Added auto-discovery of the credential definition via `ISSUER_DID` (did:webvh): if `JSON_SCHEMA_CREDENTIAL_ID` is not set, the verifier queries the issuer's DID-linked resources of type `anonCredsCredDef` and takes the first one
- Removed `CREDENTIAL_DEFINITION_ID` and `ISSUER_VS_AGENT_ADMIN_BASE_URL` — both were supported until v1.3.1 as part of 2060 demo deployments and are no longer supported
- Updated Helm chart (`values.yaml`, `deployment.yaml`) and documentation accordingly
